### PR TITLE
Clarify that Node 16+ is required for Apple Sillycone

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Service](https://docs.github.com/en/github/site-policy/github-terms-of-service#j
 
 ## Getting started
 
-1.  Install [Node.js][] 12 or newer.
+1.  Install [Node.js][] 12 or newer (Note: Node v16+ required on Apple Silicon).
 
 2.  Install [Neovim][] 0.6 or newer.
 


### PR DESCRIPTION
At the moment we are not accepting contributions to the repository.

![image](https://user-images.githubusercontent.com/3710766/144692395-352eea3c-a887-44fa-90ef-37570880181a.png)
